### PR TITLE
fix: Fix the path problem of the plugin during build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,11 @@ import { resolve } from 'path';
 import { readFileSync } from 'fs';
 
 export default (api: IApi) => {
-
   api.onGenerateFiles(() => {
-    const buffer= readFileSync(resolve('./src/.umi/umi.ts'))
-    const c = String(buffer)
+    const path =
+      api.env === 'production' ? './src/.umi/index.ts' : './src/.umi/umi.ts';
+    const buffer = readFileSync(resolve(path));
+    const c = String(buffer);
     // console.log()
     api.writeTmpFile({
       path: 'index.ts',


### PR DESCRIPTION
目前这个插件在build时存在路径问题，导致umi build后的文件出问题。
解决办法： 区分环境选择入口文件的路径