### PR TITLE
Fix ./src/.umi/index.ts or ./src/.umi/index.ts file does not exist ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 module-federation 异步启动插件
 
-
 ### change log
 
-* 0.0.2
-1. Fix the path problem of the plugin during build
+- 0.0.3
+
+1.  Fix `./src/.umi/index.ts` or `./src/.umi/index.ts` file does not exist causing error via docker build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "umi-plugin-mf-bootstrap",
-  "version": "0.0.2",
+  "version": "0.0.3",
+  "license": "MIT",
   "scripts": {
     "start": "dumi dev",
     "docs:build": "dumi build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,17 @@ import { readFileSync } from 'fs';
 
 export default (api: IApi) => {
   api.onGenerateFiles(() => {
-    const path =
-      api.env === 'production' ? './src/.umi/index.ts' : './src/.umi/umi.ts';
-    const buffer = readFileSync(resolve(path));
-    const c = String(buffer);
-    // console.log()
+    let c = '';
+    try {
+      const path =
+        api.env === 'production' ? './src/.umi/index.ts' : './src/.umi/umi.ts';
+      const buffer = readFileSync(resolve(path));
+      c = String(buffer);
+    } catch (e) {
+      console.info(
+        `src/.umi/index.ts or src/.umi/umi.ts it's not defined, set empty content to tmp file`,
+      );
+    }
     api.writeTmpFile({
       path: 'index.ts',
       content: c,


### PR DESCRIPTION
Fix ./src/.umi/index.ts or ./src/.umi/index.ts file does not exist causing error via docker build

[See ISSUE for more information](https://github.com/jiechud/umi-plugin-mf-bootstrap/issues/2)